### PR TITLE
Add missing semicolons, and remove some debugging statements.

### DIFF
--- a/UnitTests/test_ann2rr.m
+++ b/UnitTests/test_ann2rr.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 %Test the examples 

--- a/UnitTests/test_bxb.m
+++ b/UnitTests/test_bxb.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_dfa.m
+++ b/UnitTests/test_dfa.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_ecgpuwave.m
+++ b/UnitTests/test_ecgpuwave.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_edr.m
+++ b/UnitTests/test_edr.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_gqrs.m
+++ b/UnitTests/test_gqrs.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_lomb.m
+++ b/UnitTests/test_lomb.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_mat2wfdb.m
+++ b/UnitTests/test_mat2wfdb.m
@@ -15,7 +15,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_mrgann.m
+++ b/UnitTests/test_mrgann.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_msentropy.m
+++ b/UnitTests/test_msentropy.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_physionetdb.m
+++ b/UnitTests/test_physionetdb.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_rdann.m
+++ b/UnitTests/test_rdann.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
   %Example 1- Read a signal and annotaion from PhysioNet's Remote server:

--- a/UnitTests/test_rdmimic2wave.m
+++ b/UnitTests/test_rdmimic2wave.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_rdsamp.m
+++ b/UnitTests/test_rdsamp.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_snip.m
+++ b/UnitTests/test_snip.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_sortann.m
+++ b/UnitTests/test_sortann.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_sqrs.m
+++ b/UnitTests/test_sqrs.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_sumann.m
+++ b/UnitTests/test_sumann.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_tach.m
+++ b/UnitTests/test_tach.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_wabp.m
+++ b/UnitTests/test_wabp.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_wfdb2mat.m
+++ b/UnitTests/test_wfdb2mat.m
@@ -12,7 +12,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_wfdbdemo.m
+++ b/UnitTests/test_wfdbdemo.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 %Test the examples 

--- a/UnitTests/test_wfdbdesc.m
+++ b/UnitTests/test_wfdbdesc.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_wfdbtime.m
+++ b/UnitTests/test_wfdbtime.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_woody.m
+++ b/UnitTests/test_woody.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_wqrs.m
+++ b/UnitTests/test_wqrs.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_wrann.m
+++ b/UnitTests/test_wrann.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/UnitTests/test_wrapper.m
+++ b/UnitTests/test_wrapper.m
@@ -32,7 +32,7 @@ for n=1:tests
               eval(clean_up{n});
             catch
               display('Clean up failed: ')
-              warning(lasterr)
+              warning(lasterr);
             end
         end
         pass=pass+1;

--- a/UnitTests/test_wrapper.m
+++ b/UnitTests/test_wrapper.m
@@ -22,7 +22,7 @@ performance=zeros(tests,1)+NaN;
 for n=1:tests
     try
         if(verbose)
-           display(test_string{n}) 
+           display(test_string{n});
         end
         tic
         eval(test_string{n});
@@ -31,7 +31,7 @@ for n=1:tests
             try
               eval(clean_up{n});
             catch
-              display('Clean up failed: ')
+              display('Clean up failed: ');
               warning(lasterr);
             end
         end

--- a/UnitTests/test_wrapper.m
+++ b/UnitTests/test_wrapper.m
@@ -14,7 +14,7 @@ verbose=0;
 cur_dir=pwd;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 tests=length(test_string);
@@ -45,5 +45,5 @@ for n=1:tests
 end
 cd(cur_dir)
 for n=1:nargout
-        eval(['varargout{n}=' outputs{n} ';'])
+        eval(['varargout{n}=' outputs{n} ';']);
 end

--- a/UnitTests/test_wrapper.m
+++ b/UnitTests/test_wrapper.m
@@ -24,7 +24,7 @@ for n=1:tests
         if(verbose)
            display(test_string{n});
         end
-        tic
+        tic;
         eval(test_string{n});
         performance(n)=toc;
         if(~isempty(clean_up) && ~isempty(clean_up{n}))
@@ -43,7 +43,7 @@ for n=1:tests
         end
     end
 end
-cd(cur_dir)
+cd(cur_dir);
 for n=1:nargout
         eval(['varargout{n}=' outputs{n} ';']);
 end

--- a/UnitTests/test_wrsamp.m
+++ b/UnitTests/test_wrsamp.m
@@ -4,7 +4,7 @@ inputs={'verbose'};
 verbose=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/ann2rr.m
+++ b/mcode/ann2rr.m
@@ -63,7 +63,7 @@ N0=1;
 consecutiveOnly=1;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -86,7 +86,7 @@ if(config.inOctave)
     data=java2mat(data);
 end
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end
 
 

--- a/mcode/bxb.m
+++ b/mcode/bxb.m
@@ -85,7 +85,7 @@ stopTime=[];
 matchWindow=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/dfa.m
+++ b/mcode/dfa.m
@@ -82,7 +82,7 @@ slideWindowFlag=false;
 wfdb_argument={};
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 if(~isempty(p))

--- a/mcode/ecgpuwave.m
+++ b/mcode/ecgpuwave.m
@@ -118,7 +118,7 @@ pflag=[];
 signalList=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/edr.m
+++ b/mcode/edr.m
@@ -253,21 +253,21 @@ if(show)
         [0.05*scrsz(3) 0.05*scrsz(4) 0.8*scrsz(3) 0.89*scrsz(4)],...
         'Color',[1 1 1]);
     ax(1)=subplot(211);
-    plot([1:length(sample)]/fs,sample)
-    hold on
-    plot([1:length(baseline)]/fs,baseline,'g')
-    plot((tqrs-pqoff)/fs,mean(ECGm)*ones(size(tqrs)),'*m')
-    plot((tqrs+jpoff)/fs,mean(ECGm)*ones(size(tqrs)),'*c')
-    legend('filtered ecg','baseline','window start','window end')
-    set(gca,'fontsize',18)
-    xlabel('time (s)','fontsize',18)
-    ylim([mean(ECGm)-5*std(ECGm) mean(ECGm)+5*std(ECGm)])
+    plot([1:length(sample)]/fs,sample);
+    hold on;
+    plot([1:length(baseline)]/fs,baseline,'g');
+    plot((tqrs-pqoff)/fs,mean(ECGm)*ones(size(tqrs)),'*m');
+    plot((tqrs+jpoff)/fs,mean(ECGm)*ones(size(tqrs)),'*c');
+    legend('filtered ecg','baseline','window start','window end');
+    set(gca,'fontsize',18);
+    xlabel('time (s)','fontsize',18);
+    ylim([mean(ECGm)-5*std(ECGm) mean(ECGm)+5*std(ECGm)]);
     ax(2)=subplot(212);
-    plot(r_peaks,y,'r')
-    title('edr','fontsize',18)
-    set(gca,'fontsize',18)
-    xlabel('time (s)','fontsize',18)
-    linkaxes(ax,'x')
+    plot(r_peaks,y,'r');
+    title('edr','fontsize',18);
+    set(gca,'fontsize',18);
+    xlabel('time (s)','fontsize',18);
+    linkaxes(ax,'x');
 end
  y=[r_peaks y];
 end

--- a/mcode/edr.m
+++ b/mcode/edr.m
@@ -137,7 +137,6 @@ elseif data_type==1 %wfdb record
         fs=fs(channel);
     end
     % read the header
-    signal
     siginfo=wfdbdesc(signal);
     siginfo=siginfo(:,channel);
     gainstring=siginfo.Gain;

--- a/mcode/edr.m
+++ b/mcode/edr.m
@@ -94,10 +94,10 @@ inputs={'data_type','signal','r_peaks','fs','pqoff','jpoff', 'gain_ecg', 'channe
 show=0;
 Ninputs=length(inputs);
 if nargin>Ninputs
-    error('Too many input arguments')
+    error('Too many input arguments');
 end
 if nargin<3
-    error('Not enough input arguments')
+    error('Not enough input arguments');
 end
 
 for n=1:nargin
@@ -115,7 +115,7 @@ if data_type==0 %matlab
     end
     ECGm=signal*gain_ecg;
     if isempty(r_peaks)
-        error('R peaks locations not provided')
+        error('R peaks locations not provided');
     else
         tqrs=round(r_peaks*fs); %samples where I have the R peak
     end
@@ -161,7 +161,7 @@ elseif data_type==1 %wfdb record
         tqrs=round(r_peaks*fs); %samples where I have the R peak
     end
     
-else error('format data_type must be 0 or 1')
+else error('format data_type must be 0 or 1');
 end
 
 % check if signal is upside-down

--- a/mcode/edr.m
+++ b/mcode/edr.m
@@ -320,7 +320,7 @@ for j=1:50
     try
         w=bline(round(tqrs(j)-tlim2*fs):tqrs(j)-1);
     catch
-        display(j)
+        display(j);
         w=bline(1:tqrs(j)-1);
     end
     f=find(w);

--- a/mcode/edr.m
+++ b/mcode/edr.m
@@ -101,10 +101,10 @@ if nargin<3
 end
 
 for n=1:nargin
-    eval([inputs{n} '=varargin{n};'])
+    eval([inputs{n} '=varargin{n};']);
 end
 for n=nargin+1:Ninputs
-    eval([inputs{n} '=[];'])
+    eval([inputs{n} '=[];']);
 end
 
 % check format and obtain all the features I need

--- a/mcode/getWfdbClass.m
+++ b/mcode/getWfdbClass.m
@@ -14,7 +14,7 @@
 
 %endOfHelp
 
-mlock
+mlock;
 persistent config
 if(isempty(config))
     %Add classes to dynamic path

--- a/mcode/getWfdbClass.m
+++ b/mcode/getWfdbClass.m
@@ -25,7 +25,7 @@ inputs={'commandName'};
 outputs={'javaWfdbExec','config'};
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -38,5 +38,5 @@ javaWfdbExec.setWFDB_PATH(config.WFDB_PATH);
 javaWfdbExec.setWFDBCAL(config.WFDBCAL);
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end

--- a/mcode/gqrs.m
+++ b/mcode/gqrs.m
@@ -121,7 +121,7 @@ end
 
 err=javaWfdbExec.execToStringList(wfdb_argument);
 if(~isempty(strfind(err.toString,['annopen: can''t'])))
-    error(err)
+    error(err);
 end
 
 

--- a/mcode/gqrs.m
+++ b/mcode/gqrs.m
@@ -86,7 +86,7 @@ outputName=[];
 highResolution=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/lomb.m
+++ b/mcode/lomb.m
@@ -80,7 +80,7 @@ dcOffset=1;
 smooth=1;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -140,7 +140,7 @@ bit_res_suport=[8 16 32];
 
 for i=1:nargin
     if(~isempty(varargin{i}))
-        eval([params{i} '= varargin{i};'])
+        eval([params{i} '= varargin{i};']);
     end
 end
 

--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -254,13 +254,13 @@ for m=1:M
         num2str(baseline_tmp) ')/' adu{m} ' ' '0 0 ' num2str(tmp_bit1(1)) ' ' num2str(ck_sum) ' 0 ' sg_name{m}]};
 end
 if(length(y)<1)
-    error(['Converted data is empty. Exiting without saving file...'])
+    error(['Converted data is empty. Exiting without saving file...']);
 end
 
 %Write *.dat file
 fid = fopen([fname '.dat'],'wb',machine_format);
 if(~fid)
-    error(['Could not create data file for writing: ' fname])
+    error(['Could not create data file for writing: ' fname]);
 end
 
 if (bit_res==8)
@@ -271,7 +271,7 @@ end
 
 if(~count)
     fclose(fid);
-    error(['Could not data write to file: ' fname])  
+    error(['Could not data write to file: ' fname]);
 end
 
 fprintf(['Generated *.dat file: ' fname '\n'])
@@ -281,7 +281,7 @@ fclose(fid);
 fid = fopen([fname '.hea'],'w');
 for m=1:M+1
     if(~fid)
-        error(['Could not create header file for writing: ' fname])
+        error(['Could not create header file for writing: ' fname]);
     end
     fprintf(fid,'%s\n',head_str{m});
 end

--- a/mcode/mat2wfdb.m
+++ b/mcode/mat2wfdb.m
@@ -144,7 +144,7 @@ for i=1:nargin
     end
 end
 
-disp(isdigital)
+disp(isdigital);
 % Check valid gain and baseline combinations depending on whether the input is digital or physical.
 if isdigital % digital input signal
     if (isempty(gain) || isempty(baseline))
@@ -274,7 +274,7 @@ if(~count)
     error(['Could not data write to file: ' fname]);
 end
 
-fprintf(['Generated *.dat file: ' fname '\n'])
+fprintf(['Generated *.dat file: ' fname '\n']);
 fclose(fid);
 
 %Write *.hea file
@@ -299,7 +299,7 @@ end
 if(nargout==1)
     varargout(1)={y};
 end
-fprintf(['Generated *.hea file: ' fname '\n'])
+fprintf(['Generated *.hea file: ' fname '\n']);
 fclose(fid);
 
 end

--- a/mcode/mrgann.m
+++ b/mcode/mrgann.m
@@ -71,7 +71,7 @@ inputs={'recName','annName1','annName2','outAnn','verbose'};
 verbose=1;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/msentropy.m
+++ b/mcode/msentropy.m
@@ -169,7 +169,7 @@ else
 end
 M=length(out);
 if(M<4)
-    error(['Error calculating MSE:' out{:}])
+    error(['Error calculating MSE:' out{:}]);
 end
 info=out(1:3);
 out(1:4)=[];

--- a/mcode/msentropy.m
+++ b/mcode/msentropy.m
@@ -111,7 +111,7 @@ y=[];
 x=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 if(~isempty(dn))
@@ -184,6 +184,6 @@ for m=1:M
 end
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end
 

--- a/mcode/nativelibs/Makefile
+++ b/mcode/nativelibs/Makefile
@@ -19,17 +19,15 @@ host=custom
 
 #Package names and versions
 
-CURL_PKG=curl-7.57.0
+CURL_PKG=curl-7.58.0
 CURL_ARCHIVE=$(CURL_PKG).tar.gz
 CURL_SOURCE=http://curl.haxx.se/download/$(CURL_ARCHIVE)
-CURL_SHA256=7ce35f207562674e71dbada6891b37e3f043c1e7a82915cb9c2a17ad3a9d659b
+CURL_SHA256=cc245bf9a1a42a45df491501d97d5593392a03f7b4f07b952793518d97666115
 
 WFDB_PKG=wfdb-10.6.0
-#WFDB_ARCHIVE=$(WFDB_PKG).tar.gz
-#WFDB_SOURCE=http://www.physionet.org/physiotools/archives/wfdb-10.5/$(WFDB_ARCHIVE)
-WFDB_ARCHIVE=wfdb-10.6.0pre2.tar.gz
-WFDB_SOURCE=http://www.physionet.org/physiotools/beta/$(WFDB_ARCHIVE)
-WFDB_SHA256=7db431bb4e12a0e5ca9ebcfb072b341e58cb4daaf6d58deb5c39168941f2a562
+WFDB_ARCHIVE=$(WFDB_PKG).tar.gz
+WFDB_SOURCE=http://www.physionet.org/physiotools/archives/wfdb-10.6/$(WFDB_ARCHIVE)
+WFDB_SHA256=6b2bcc76e0e613b91c30d6f825c087895ff7f76d50664f8f367b4008f82709fd
 WFDB_MAJOR=10
 
 ECGPUWAVE_PKG=ecgpuwave-1.3.3
@@ -204,7 +202,7 @@ $(CURL_ARCHIVE):
 	mv curl.tar.gz $(CURL_ARCHIVE)
 $(BUILD_DIR)/curl.isconfig: $(CURL_ARCHIVE)
 	mkdir -p $(BUILD_DIR)
-	( cd $(BUILD_DIR) && tar xfz $(SRC_DIR)/$(CURL_ARCHIVE) )
+	tar -xzf $(CURL_ARCHIVE) -C $(BUILD_DIR)
 	( cd $(BUILD_DIR)/$(CURL_PKG) && \
 	  ./configure $(configure_args) \
 	    CC="$(CC)" \
@@ -257,7 +255,7 @@ $(WFDB_ARCHIVE):
 $(BUILD_DIR)/wfdb.isconfig: PATH:=$(buildbindir):$(PATH)
 $(BUILD_DIR)/wfdb.isconfig: $(WFDB_ARCHIVE) $(BUILD_DIR)/curl.isbuilt
 	mkdir -p $(BUILD_DIR)
-	( cd $(BUILD_DIR) && tar xfz $(SRC_DIR)/$(WFDB_ARCHIVE) )
+	tar -xzf $(WFDB_ARCHIVE) -C $(BUILD_DIR)
 	( cd $(BUILD_DIR)/$(WFDB_PKG) && \
 	  ./configure $(configure_args) \
 	    --prefix=$(prefix) \
@@ -413,7 +411,7 @@ $(BUILD_DIR)/ecgpuwave.isbuilt: PATH:=$(buildbindir):$(PATH)
 $(BUILD_DIR)/ecgpuwave.isbuilt: $(BUILD_DIR)/wfdb.isbuilt
 $(BUILD_DIR)/ecgpuwave.isbuilt: $(ECGPUWAVE_ARCHIVE)
 	mkdir -p $(BUILD_DIR)
-	( cd $(BUILD_DIR) && tar xfz $(SRC_DIR)/$(ECGPUWAVE_ARCHIVE) )
+	tar -xzf $(ECGPUWAVE_ARCHIVE) -C $(BUILD_DIR)
 	( cd $(BUILD_DIR)/$(ECGPUWAVE_PKG) && \
 	  $(MAKE) CC="$(CC)" F77="$(F77)" \
 	    WFDB_CFLAGS="-I$(includedir)" \

--- a/mcode/physionetdb.m
+++ b/mcode/physionetdb.m
@@ -75,7 +75,7 @@ DoBatchDownload=0;
 webBrowser=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 if(webBrowser && config.inOctave)

--- a/mcode/physionetdb.m
+++ b/mcode/physionetdb.m
@@ -95,14 +95,14 @@ if(isempty(db_name))
             web([PHYSIONET_URL 'DBS'])
         else
             for i=0:double(list.size)-1
-                fprintf(char(list.get(i).getDBInfo))
+                fprintf(char(list.get(i).getDBInfo));
                 fprintf('\n');
             end
         end
     end
 else
     if(DoBatchDownload)
-        display(['Making directory: ' db_name ' to store record files'])
+        display(['Making directory: ' db_name ' to store record files']);
         mkdir(db_name)
     end
     rec_list={};
@@ -115,7 +115,7 @@ else
         for i=1:Nstr
             if(DoBatchDownload)
                 recName=rec_list{i};
-                display(['Downloading record (' num2str(i+1) ' / ' Nstr ') : ' recName])
+                display(['Downloading record (' num2str(i+1) ' / ' Nstr ') : ' recName]);
                 [success,files_saved]=wfdbdownload([db_name '/' recName]);
             end
         end

--- a/mcode/physionetdb.m
+++ b/mcode/physionetdb.m
@@ -79,7 +79,7 @@ for n=1:nargin
     end
 end
 if(webBrowser && config.inOctave)
-    error('Web browser option is not available in Octave.')
+    error('Web browser option is not available in Octave.');
 end
 
 if(isempty(db_name))

--- a/mcode/physionetdb.m
+++ b/mcode/physionetdb.m
@@ -92,7 +92,7 @@ if(isempty(db_name))
         varargout(1)={db_list};
     else
         if(webBrowser)
-            web([PHYSIONET_URL 'DBS'])
+            web([PHYSIONET_URL 'DBS']);
         else
             for i=0:double(list.size)-1
                 fprintf(char(list.get(i).getDBInfo));
@@ -103,11 +103,11 @@ if(isempty(db_name))
 else
     if(DoBatchDownload)
         display(['Making directory: ' db_name ' to store record files']);
-        mkdir(db_name)
+        mkdir(db_name);
     end
     rec_list={};
     if(webBrowser)
-        web([PHYSIONET_URL 'pbi/' db_name])
+        web([PHYSIONET_URL 'pbi/' db_name]);
     else
         rec_list=deblank(urlread([PHYSIONET_URL db_name '/RECORDS']));
         rec_list=regexp(rec_list,'\s','split');

--- a/mcode/rdann.m
+++ b/mcode/rdann.m
@@ -133,7 +133,7 @@ if(~isempty(N0) && N0>1)
         wfdb_argument{end+1}='-f';
         wfdb_argument{end+1}=[start_time{1}];
     else
-        error(['Could not get record header information to find start time.'])
+        error(['Could not get record header information to find start time.']);
     end
     
 end
@@ -146,7 +146,7 @@ if(~isempty(N))
         wfdb_argument{end+1}='-t';
         wfdb_argument{end+1}=[end_time{1}];
     else
-        error(['Could not get record header information to find stop time.'])
+        error(['Could not get record header information to find stop time.']);
     end
 end
 
@@ -187,7 +187,7 @@ else
     comments=cell(N,1);
     str=char(data(1));
     if(~isempty(strfind(str,'init: can''t open header for record')))
-        error(str)
+        error(str);
     end
     if(~isempty(str) && strcmp(str(1),'['))
         % Absolute time stamp. Also possibly a date stamp
@@ -227,7 +227,7 @@ else
         % 0:00.355      355     N    0    0    0
         str=data(1);
         if(~isempty(strfind(str,['annopen: can''t read annotator'])))
-            error(str)
+            error(str);
         end
         for n=1:N
             str=char(data(n));

--- a/mcode/rdann.m
+++ b/mcode/rdann.m
@@ -114,7 +114,7 @@ C=[];
 AT=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -260,7 +260,7 @@ end
 ann=ann+1; %Convert to MATLAB indexing
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end
 
 

--- a/mcode/rdmat.m
+++ b/mcode/rdmat.m
@@ -68,7 +68,7 @@ defGain=200; %Default value for missing gains
 
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -172,7 +172,7 @@ tm =linspace(0,(N-1)/Fs,N);
 
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end
 
 

--- a/mcode/rdmat.m
+++ b/mcode/rdmat.m
@@ -75,7 +75,7 @@ end
 outputs={'tm','val','Fs','siginfo'};
 fid = fopen([recordName, '.hea'], 'rt');
 if(fid==-1)
-    error(['Could not open file: ' recordName '.hea !'])
+    error(['Could not open file: ' recordName '.hea !']);
 end
 
 %Following the documentation described in :

--- a/mcode/rdmimic2wave.m
+++ b/mcode/rdmimic2wave.m
@@ -116,7 +116,7 @@ sigInfo=[];
 recList=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -155,7 +155,7 @@ if(isempty(subjectID))
     %records
     recList=matched_id;
     for n=1:nargout
-        eval(['varargout{n}=' outputs{n} ''])
+        eval(['varargout{n}=' outputs{n} '']);
     end
     return
     
@@ -178,7 +178,7 @@ if(~isempty(matched_pid))
     %Get all records that match the patient and search for a record
     %that includes the clinical time
     strSubjectID=sprintf('%05d',subjectID);
-    eval(['recs=regexp(regexp(matched,''(\<s' strSubjectID '.*)'',''match''),''\n'',''split'');'])
+    eval(['recs=regexp(regexp(matched,''(\<s' strSubjectID '.*)'',''match''),''\n'',''split'');']);
     recs=recs{:};
     N=length(recs);
     for n=1:N
@@ -224,7 +224,7 @@ end
 
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end
 
 

--- a/mcode/rdmimic2wave.m
+++ b/mcode/rdmimic2wave.m
@@ -134,7 +134,7 @@ if(~strcmp(cachedDataType,dataType))
         case 'waveform'
             matched=urlread('http://www.physionet.org/physiobank/database/mimic2wdb/matched/RECORDS-waveforms');
         otherwise
-            error(['Unknow dataType. Options are: ''numerics'', ''all'', or ''waveform'''])
+            error(['Unknow dataType. Options are: ''numerics'', ''all'', or ''waveform''']);
     end
     cachedDataType=dataType;
     

--- a/mcode/rdsamp.m
+++ b/mcode/rdsamp.m
@@ -269,7 +269,7 @@ end
 %because it may not be for multiresolution signals
 if(length(signalList)==1 && rawUnits<3 && (rawUnits ~= 0) )
     err=abs(Fs-Fstest);
-    if(err>1)siginfo
+    if(err>1)
         warning([ 'Sampling frequency maybe incorrect! ' ...
             'Switching from ' num2str(Fs) ' to: ' num2str(Fstest)]);
         Fs=Fstest;

--- a/mcode/rdsamp.m
+++ b/mcode/rdsamp.m
@@ -141,7 +141,7 @@ if(isempty(N) && (rawUnits ~=0))
     if(~isempty(siginfo))
         N=siginfo(1).LengthSamples;
     else
-        warning('Could not get signal information. Attempting to read signal without buffering.')
+        warning('Could not get signal information. Attempting to read signal without buffering.');
     end
 end
 
@@ -271,7 +271,7 @@ if(length(signalList)==1 && rawUnits<3 && (rawUnits ~= 0) )
     err=abs(Fs-Fstest);
     if(err>1)siginfo
         warning([ 'Sampling frequency maybe incorrect! ' ...
-            'Switching from ' num2str(Fs) ' to: ' num2str(Fstest)])
+            'Switching from ' num2str(Fs) ' to: ' num2str(Fstest)]);
         Fs=Fstest;
     end
 end
@@ -289,7 +289,7 @@ for n=1:nargout
     end
     if(~isempty(ListCapacity) && ~isnan(ListCapacity) )
         if((ListCapacity) ~= N )
-            warning(['Received: ' num2str(N) ' samples, expected: '  num2str(ListCapacity)])
+            warning(['Received: ' num2str(N) ' samples, expected: '  num2str(ListCapacity)]);
         end
     end
 end

--- a/mcode/rdsamp.m
+++ b/mcode/rdsamp.m
@@ -245,7 +245,7 @@ switch rawUnits
         end
         data=javaWfdbExec.execToLongArray(wfdb_argument);
     otherwise
-        error(['Unknown rawUnits option: ' num2str(rawUnits)])
+        error(['Unknown rawUnits option: ' num2str(rawUnits)]);
 end
 
 if(config.inOctave)
@@ -284,7 +284,7 @@ for n=1:nargout
     if(~isempty(signalList) )
         sList=length(signalList);
         if(sList ~= (M))
-            error(['Received: ' num2str(M) ' signals, expected: '  num2str(length(signalList))])
+            error(['Received: ' num2str(M) ' signals, expected: '  num2str(length(signalList))]);
         end
     end
     if(~isempty(ListCapacity) && ~isnan(ListCapacity) )

--- a/mcode/rdsamp.m
+++ b/mcode/rdsamp.m
@@ -103,7 +103,7 @@ signal=[];
 highResolution=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -277,7 +277,7 @@ if(length(signalList)==1 && rawUnits<3 && (rawUnits ~= 0) )
 end
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
     
     %Perform minor data integrity check by validating with the expected
     %sizes

--- a/mcode/snip.m
+++ b/mcode/snip.m
@@ -72,7 +72,7 @@ inputAnn=[];
 outFormat=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/sortann.m
+++ b/mcode/sortann.m
@@ -60,7 +60,7 @@ stopTime=[];
 outFile=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/sqrs.m
+++ b/mcode/sqrs.m
@@ -71,7 +71,7 @@ signal=[]; %use application default
 threshold=[];%use application default
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/sumann.m
+++ b/mcode/sumann.m
@@ -56,7 +56,7 @@ stopTime=[];
 qrsAnnotationsOnly=0;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/tach.m
+++ b/mcode/tach.m
@@ -63,7 +63,7 @@ N0=1;
 ouputSize=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -86,7 +86,7 @@ if(config.inOctave)
     data=java2mat(data);
 end
 for n=1:nargout
-        eval(['varargout{n}=' outputs{n} ';'])
+        eval(['varargout{n}=' outputs{n} ';']);
 end
 
 

--- a/mcode/wabp.m
+++ b/mcode/wabp.m
@@ -124,7 +124,7 @@ end
 
 err=javaWfdbExec.execToStringList(wfdb_argument);
 if(~isempty(strfind(err.toString,['annopen: can''t'])))
-    error(err)
+    error(err);
 end
 
 

--- a/mcode/wabp.m
+++ b/mcode/wabp.m
@@ -92,7 +92,7 @@ resample=0;
 signal=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/wfdb2mat.m
+++ b/mcode/wfdb2mat.m
@@ -62,7 +62,7 @@ N=[];
 N0=1;
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/wfdbdemo.m
+++ b/mcode/wfdbdemo.m
@@ -16,8 +16,8 @@ display('Reading and plotting annotations (human labels) of QRS complexes perfor
 [ann,type,subtype,chan,num]=rdann('mitdb/100','atr',1,N);
 
 %Plot 2D version of signal and labels
-figure
-plot(tm(1:N),ecg(1:N));hold on;grid on
+figure;
+plot(tm(1:N),ecg(1:N));hold on;grid on;
 plot(tm(ann(ann<N)+1),ecg(ann(ann<N)+1),'ro');
 
 
@@ -38,27 +38,27 @@ end
 %Clifford GD, Azuaje F, McSharry PE, editors.
 %Advanced Methods and Tools for ECG Analysis.
 %1st ed., Norwood, MA, USA: Artech House; 2006. (Engineering in Medicine and Biology; 1).
-figure
+figure;
 [X,Y] = meshgrid(1:min(RR)+1,1:M);
-surf(Y,X,stack);hold on;grid on
-shading interp
-plot3(1:M,qrs(:,1),qrs(:,2)+offset,'go-','MarkerFaceColor','g')
+surf(Y,X,stack);hold on;grid on;
+shading interp;
+plot3(1:M,qrs(:,1),qrs(:,2)+offset,'go-','MarkerFaceColor','g');
 view(120, 30);
-axis off
+axis off;
 
 %Generate plot inspired by
 % Samenie et al
 % "Filtering Noisy ECG Signals Using Extended Kalman Filter Based on a
 % Modified Dynamic ECG Model"
 % Computers in Cardiology, 2005
-figure
+figure;
 stack=stack';
 stack=stack(:)+[0:length(stack(:))-1]'.*0.0005;
 theta=linspace(0,M*2*pi,length(stack));
 x=sin(theta);y=cos(theta);
-plot3(x,y,stack,'b')
-grid on
-axis off
+plot3(x,y,stack,'b');
+grid on;
+axis off;
 
 %Display information about databases availabe in PhysioNet
 fprintf('**Querying PhysioNet for available databases...\n');

--- a/mcode/wfdbdemo.m
+++ b/mcode/wfdbdemo.m
@@ -7,11 +7,11 @@ function wfdbdemo()
 
 [~,config]=wfdbloadlib;
 echo on
-display('Reading samples ECG signal from MIT-BIH Arrhythmia Database')
+display('Reading samples ECG signal from MIT-BIH Arrhythmia Database');
 N=10000;
 [ecg,Fs,tm]=rdsamp('mitdb/100',1,N);
 
-display('Reading and plotting annotations (human labels) of QRS complexes performend on the signals')
+display('Reading and plotting annotations (human labels) of QRS complexes performend on the signals');
 %by cardiologists.
 [ann,type,subtype,chan,num]=rdann('mitdb/100','atr',1,N);
 
@@ -22,7 +22,7 @@ plot(tm(ann(ann<N)+1),ecg(ann(ann<N)+1),'ro');
 
 
 %Stack the ECG signals based on the labeled QRSs
-display('Ploting 3D version of signal and labels')
+display('Ploting 3D version of signal and labels');
 [RR,tms]=ann2rr('mitdb/100','atr',N);
 delay=round(0.1/tm(2));
 M=length(RR);
@@ -61,11 +61,11 @@ grid on
 axis off
 
 %Display information about databases availabe in PhysioNet
-fprintf('**Querying PhysioNet for available databases...\n')
+fprintf('**Querying PhysioNet for available databases...\n');
 db_list=physionetdb;
 db_size=length(db_list);
-fprintf(['\tYou currently have access to ' num2str(db_size) ' databases for download in PhysioNet (type ''help physionetdb'' for more info)!\n'])
+fprintf(['\tYou currently have access to ' num2str(db_size) ' databases for download in PhysioNet (type ''help physionetdb'' for more info)!\n']);
 
-display('Demoing finished !!')
-display('For more information about the toolbox, type ''wfdb'' at the command prompt.')
+display('Demoing finished !!');
+display('For more information about the toolbox, type ''wfdb'' at the command prompt.');
 echo off

--- a/mcode/wfdbdemo.m
+++ b/mcode/wfdbdemo.m
@@ -6,7 +6,7 @@ function wfdbdemo()
 %
 
 [~,config]=wfdbloadlib;
-echo on
+echo on;
 display('Reading samples ECG signal from MIT-BIH Arrhythmia Database');
 N=10000;
 [ecg,Fs,tm]=rdsamp('mitdb/100',1,N);
@@ -68,4 +68,4 @@ fprintf(['\tYou currently have access to ' num2str(db_size) ' databases for down
 
 display('Demoing finished !!');
 display('For more information about the toolbox, type ''wfdb'' at the command prompt.');
-echo off
+echo off;

--- a/mcode/wfdbdesc.m
+++ b/mcode/wfdbdesc.m
@@ -96,7 +96,7 @@ outputs={'siginfo','Fs','sigClass'};
 
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -193,7 +193,7 @@ if(nargout>2)
     sigClass=getSignalClass(siginfo,config);
 end
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end
 
 

--- a/mcode/wfdbdownload.m
+++ b/mcode/wfdbdownload.m
@@ -54,7 +54,7 @@ success=0;
 files_saved={};
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -101,5 +101,5 @@ else
 end
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end

--- a/mcode/wfdbdownload.m
+++ b/mcode/wfdbdownload.m
@@ -90,7 +90,7 @@ else
                 [config.CACHE_DEST recordName wfdb_extensions{m}],'Timeout',timeout);
             if(~isempty(furl))
                 files_saved{end+1}=furl;
-                warning(['Downloaded WFDB cache file: ' furl])
+                warning(['Downloaded WFDB cache file: ' furl]);
             end
             catch
                %Do nothing, because some extensions will not exist 

--- a/mcode/wfdbloadlib.m
+++ b/mcode/wfdbloadlib.m
@@ -78,7 +78,7 @@ networkWaitTime=1000;
 inputs={'debugLevel','networkWaitTime'};
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -133,7 +133,7 @@ if(isempty(config))
             varname=strrep(tmpstr{1},'[','');
             varname=strrep(varname,' ','');
             varname=strrep(varname,']','');
-            eval(['config.' varname '=''' tmpstr{2} ''';'])
+            eval(['config.' varname '=''' tmpstr{2} ''';']);
         end
         config.MATLAB_PATH=strrep(which('wfdbloadlib'),'wfdbloadlib.m','');
         wver=regexp(wfdb_path,fsep,'split');
@@ -194,7 +194,7 @@ end
 
 outputs={'isloaded','config'};
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end
 
 

--- a/mcode/wfdbloadlib.m
+++ b/mcode/wfdbloadlib.m
@@ -109,8 +109,8 @@ if(isempty(isloaded))
     %issue a warning if there is
     warnMe=strfind(wfdb_path,' ');
     if(~isempty(warnMe))
-       warning('Your WFDB Toolbox installation  path contain white spaces!! This may cause issues with the WFDB Toolbox!') 
-       warning(['The installation path is set to: ' wfdb_path])
+       warning('Your WFDB Toolbox installation  path contain white spaces!! This may cause issues with the WFDB Toolbox!');
+       warning(['The installation path is set to: ' wfdb_path]);
     end
 end
 
@@ -158,7 +158,7 @@ if(isempty(config))
         config.WFDB_CUSTOMLIB=WFDB_CUSTOMLIB;
             warnMe=strfind(wfdb_path,' ');
     if(~isempty(warnMe))
-       warning('Your WFDB Toolbox installation  path contain white spaces!! This may cause issues with the WFDB Toolbox!') 
+       warning('Your WFDB Toolbox installation  path contain white spaces!! This may cause issues with the WFDB Toolbox!');
     end
     
     %Set CACHE configurations
@@ -167,7 +167,7 @@ if(isempty(config))
         if(~isempty(ind))
             CACHE_SOURCE=config.WFDB_PATH(ind:end);
         else
-            warning(['Could not set CACHE, CACHE_SOURCE invalid'])
+            warning(['Could not set CACHE, CACHE_SOURCE invalid']);
             CACHE=0;   
         end
     end
@@ -179,7 +179,7 @@ if(isempty(config))
             mkdir(CACHE_DEST);
         end
         if(~isdir(CACHE_DEST))
-            warning(['Could not set CACHE, CACHE_DEST directory does not exist: ' CACHE_DEST])
+            warning(['Could not set CACHE, CACHE_DEST directory does not exist: ' CACHE_DEST]);
             CACHE=0;   
         end
     end

--- a/mcode/wfdbloadlib.m
+++ b/mcode/wfdbloadlib.m
@@ -28,7 +28,7 @@ function [varargout]=wfdbloadlib(varargin)
 %
 
 %endOfHelp
-mlock
+mlock;
 persistent isloaded wfdb_path wfdb_native_path config
 
 %%%%% SYSTEM WIDE CONFIGURATION PARAMETERS %%%%%%%
@@ -102,7 +102,7 @@ if(isempty(isloaded))
     end
     %Check if path has not been added yet
     wfdb_path=[wfdb_path 'wfdb-app-JVM7-0-10-0.jar'];
-    javaaddpath(wfdb_path)
+    javaaddpath(wfdb_path);
     isloaded=1;
     
     %Check if there are any empty space on the path directory, and 

--- a/mcode/wfdbtime.m
+++ b/mcode/wfdbtime.m
@@ -52,7 +52,7 @@ inputs={'recordName','samples'};
 outputs={'timeStamp','dateStamp'};
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 
@@ -88,5 +88,5 @@ for n=1:length(data)
 end
 
 for n=1:nargout
-    eval(['varargout{n}=' outputs{n} ';'])
+    eval(['varargout{n}=' outputs{n} ';']);
 end

--- a/mcode/woody.m
+++ b/mcode/woody.m
@@ -134,7 +134,7 @@ switch est_mthd
         
         
     otherwise
-        error(['Invalid option for est_mthd parameter: ' xcorr_mthd ' valid options are: woody, weighted, and thornton'])
+        error(['Invalid option for est_mthd parameter: ' xcorr_mthd ' valid options are: woody, weighted, and thornton']);
 end
 
 

--- a/mcode/wqrs.m
+++ b/mcode/wqrs.m
@@ -95,7 +95,7 @@ powerLineFrequency=[];
 resample=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/wrann.m
+++ b/mcode/wrann.m
@@ -102,7 +102,7 @@ comments={''};
 % Read in input arguments
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 

--- a/mcode/wrann.m
+++ b/mcode/wrann.m
@@ -178,7 +178,7 @@ end
 javaWfdbExec.setArguments(wfdb_argument);
 err=javaWfdbExec.execWithStandardInput(data);
 if(~isempty(strfind(err.toString,['annopen: can''t'])))
-    error(char(err.toString))
+    error(char(err.toString));
 end
 
 end

--- a/mcode/wrsamp.m
+++ b/mcode/wrsamp.m
@@ -86,7 +86,7 @@ gain=[];
 format=[];
 for n=1:nargin
     if(~isempty(varargin{n}))
-        eval([inputs{n} '=varargin{n};'])
+        eval([inputs{n} '=varargin{n};']);
     end
 end
 


### PR DESCRIPTION
These patches add missing semicolons in numerous places, to avoid
(unintended) output to the terminal and to avoid missing-semicolon
warnings if they are enabled.

The first six patches in this series only affect statements that do
not produce any output, and thus these patches should have no effect
besides avoiding spurious warnings.

The last two patches remove two debugging statements that appear to
have been left in unintentionally.